### PR TITLE
[chore] Enable option to skip docs generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.8)
 
 project(ORE CXX)
 
+option(BUILD_DOC "Build documentation" ON)
+
 include(CTest)
 
 include("cmake/commonSettings.cmake")

--- a/OREAnalytics/doc/CMakeLists.txt
+++ b/OREAnalytics/doc/CMakeLists.txt
@@ -1,9 +1,6 @@
-# first we can indicate the documentation build as an option and set it to ON by default
-option(BUILD_DOC "Build documentation" ON)
-
 # check if Doxygen is installed
 find_package(Doxygen)
-if (DOXYGEN_FOUND)
+if (DOXYGEN_FOUND AND BUILD_DOC)
     # set input and output files
     set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/orea.doxy)
     set(DOXYGEN_OUT ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile)

--- a/OREData/doc/CMakeLists.txt
+++ b/OREData/doc/CMakeLists.txt
@@ -1,9 +1,6 @@
-# first we can indicate the documentation build as an option and set it to ON by default
-option(BUILD_DOC "Build documentation" ON)
-
 # check if Doxygen is installed
 find_package(Doxygen)
-if (DOXYGEN_FOUND)
+if (DOXYGEN_FOUND AND BUILD_DOC)
     # set input and output files
     set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/ored.doxy)
     set(DOXYGEN_OUT ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile)

--- a/QuantExt/doc/CMakeLists.txt
+++ b/QuantExt/doc/CMakeLists.txt
@@ -1,9 +1,6 @@
-# first we can indicate the documentation build as an option and set it to ON by default
-option(BUILD_DOC "Build documentation" ON)
-
 # check if Doxygen is installed
 find_package(Doxygen)
-if (DOXYGEN_FOUND)
+if (DOXYGEN_FOUND AND BUILD_DOC)
     # set input and output files
     set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/quantext.doxy)
     set(DOXYGEN_OUT ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile)


### PR DESCRIPTION
Move the BUILD_DOC option to the parent CMakeLists.txt and query
its value in the directives which trigger a doxygen build.